### PR TITLE
Client now able to send multiple files for transactions, transaction_items and users datasets. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/datasets

--- a/client/file_manager.go
+++ b/client/file_manager.go
@@ -195,7 +195,8 @@ func (f *FileManager) createTransactionRecord(record []string) (protocol.Transac
 
 	for i := range record {
 		record[i] = strings.TrimSpace(record[i])
-		if record[i] == "" {
+		// voucher_id and user_id can be empty
+		if record[i] == "" && i != common.CSV_TXN_VOUCHER_ID && i != common.CSV_TXN_USER_ID {
 			return protocol.TransactionRecord{}, fmt.Errorf("field %d is empty", i)
 		}
 	}

--- a/client/file_manager.go
+++ b/client/file_manager.go
@@ -115,7 +115,8 @@ func (f *FileManager) createMenuItemRecord(record []string) (protocol.MenuItemRe
 
 	for i := range record {
 		record[i] = strings.TrimSpace(record[i])
-		if record[i] == "" {
+		// available_from and available_to can be empty
+		if record[i] == "" && i != common.CSV_AVAILABLE_FROM && i != common.CSV_AVAILABLE_TO {
 			return protocol.MenuItemRecord{}, fmt.Errorf("field %d is empty", i)
 		}
 	}

--- a/common/constants.go
+++ b/common/constants.go
@@ -48,7 +48,7 @@ const (
 	MAX_SEND_RETRIES         = 3        // Maximum retries for sending messages
 
 	// CSV processing limits
-	MAX_CSV_RECORDS = 100000 // Maximum number of valid records to process from CSV
+	MAX_CSV_RECORDS = 10000000 // Maximum number of valid records to process from CSV
 
 	// Protocol constants
 	LENGTH_PREFIX_BYTES = 4 // Length prefix size in bytes

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,6 @@ output:
 datasets:
   menuItems: "./datasets/menu_items/menu_items.csv"
   stores: "./datasets/stores/stores.csv"
-  transactionItems: "./datasets/transaction_items/transaction_items_202307.csv"
-  transactions: "./datasets/transactions/transactions_202307.csv"
-  users: "./datasets/users/users_202307.csv"
+  transactionItems: "./datasets/transaction_items/"
+  transactions: "./datasets/transactions/"
+  users: "./datasets/users/"


### PR DESCRIPTION
The client now supports processing entire directories containing multiple CSV files for transactions, transaction_items, and users datasets. Menu_items and stores continue to work as single files.

Added gitignore, datasets should be stored locally.

Also some minor issues fixed:
- Dataset menu_items is now sent to the server (previously validation rejected all records due to empty fields)
- Dataset transactions is now sent to the server (previously validation most of the records due to empty fields)
- Limit of 100k records per CSV removed, now the client can process CSVs with up to 10M rows